### PR TITLE
Add NotFair – open-source Claude Code skills for SEO & paid ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A curated collection of the **best AI tools** categorized for easy discovery. Co
 | [HyperWrite](https://www.hyperwriteai.com)    | AI assistant for writing emails and replies in-browser.        | Freemium    | Unlimited usage with limited features |
 | [INK for All](https://inkforall.com)          | AI writing + SEO optimization for higher ranking content.      | Freemium    | Free plan with core features          |
 | [Scalenut](https://www.scalenut.com)          | AI writer + SEO planner for long-form content/blogs.           | Freemium    | 7-day free trial                      |
+| [NotFair](https://github.com/nowork-studio/NotFair) | Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads; connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. (~2.9k stars) | Free | Open-source (MIT)                     |
 
 ---
 


### PR DESCRIPTION
Hi! Thanks for maintaining this great list of AI tools.

I'd like to suggest adding **[NotFair](https://github.com/nowork-studio/NotFair)**, an open-source (MIT) set of Claude Code agent skills for SEO, GEO, Google Ads, and Meta Ads. It has ~2.9k GitHub stars and is actively maintained.

It seemed like a natural fit for the **Writing Tools** section, which covers marketing and SEO tools. NotFair connects to live campaign and analytics data through four MCP integrations: **Google Ads MCP**, **Meta Ads MCP**, **Google Search Console MCP**, and **Google Analytics (GA4) MCP** — making it a hands-on tool for marketers working with AI.

Happy to move it to a different section, adjust the description, or trim any details if needed. Thanks for your time!