### PR TITLE
Add GPT Image 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A curated collection of the **best AI tools** categorized for easy discovery. Co
 | [StarryAI](https://www.starryai.com)                                         | AI art generator for NFTs and digital art.            | Freemium | 5 free creations/day                          |
 | [Photosonic by Writesonic](https://photosonic.writesonic.com)                | AI image generation by the makers of Writesonic.      | Freemium | 15 free credits                               |
 | [Magic Studio](https://magicstudio.com/tools/ai-image-generator)             | Create product shots, background removal + image gen. | Freemium | Free basic features                           |
+| [GPT Image 2](https://gptimage2.asia/)                                    | Create and edit production-ready AI images for marketing, ecommerce, social media, and branded content. | Freemium | Free trial / credits                        |
 
 ---
 


### PR DESCRIPTION
## Summary
Adds GPT Image 2 to the Image Generation section.

Added row:

| [GPT Image 2](https://gptimage2.asia/)                                    | Create and edit production-ready AI images for marketing, ecommerce, social media, and branded content. | Freemium | Free trial / credits                        |

Disclosure: submitted by the project owner/operator.