### PR TITLE
Add Rao Edits to image generation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ A curated collection of the **best AI tools** categorized for easy discovery. Co
 | [StarryAI](https://www.starryai.com)                                         | AI art generator for NFTs and digital art.            | Freemium | 5 free creations/day                          |
 | [Photosonic by Writesonic](https://photosonic.writesonic.com)                | AI image generation by the makers of Writesonic.      | Freemium | 15 free credits                               |
 | [Magic Studio](https://magicstudio.com/tools/ai-image-generator)             | Create product shots, background removal + image gen. | Freemium | Free basic features                           |
+| [Rao Edits](https://raoedits.top/)                                           | Generate images from text or references and edit photos for creator workflows. | Paid | No free trial; plans from $29/month |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [Rao Edits](https://raoedits.top/) to the Image Generation comparison table.

- supports text-to-image and reference-image editing
- categorized accurately as paid
- notes the current entry price of $29/month and absence of a free trial

The website and public pricing page were checked before submission. This is a one-line README-only addition matching the format of recent merged tool entries.